### PR TITLE
Fix config for CI coverage report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
     - run:
         name: Send test results to Coveralls
         command: |
-          docker run --env-file .coveralls.env nodefactory/nodejs-ts-starter:${CIRCLE_SHA1} sh -c "npm run coverage && npm run coveralls"
+          docker run --env-file .coveralls.env nodefactory/nodejs-ts-starter:${CIRCLE_SHA1} sh -c "yarn pretest && yarn coverage && yarn coveralls"
     - run:
         name: Save docker layers cache
         command: |


### PR DESCRIPTION
Quick fix for coverage that needs .js files.

However, this also exists: https://www.npmjs.com/package/@istanbuljs/nyc-config-typescript